### PR TITLE
Add logging and simplified run command

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -27,14 +27,10 @@ to activate the environment in current shell.
 ## Run
 ```bash
 cd /path/to/backend/
-uvicorn app.main:app --reload
-```
-In WSL
-```bash
-uvicorn app.main:app --reload --host [wsl_ip]
+./run.sh [port=8000]
 ```
 
-The app will be available on localhost:8000.
+The app will run on $(hostname --all-ip-address):port(=8000), which is often the desired behavior.
 
 Visit
 ```
@@ -53,3 +49,8 @@ python -m app.update_static
 cd /path/to/backend/
 python -m app.gen_test_history
 ```
+
+## Logs
+Log files are available in `/path/to/backend/logs`
+
+Note that logs are cleared at next run.

--- a/backend/log_conf.json
+++ b/backend/log_conf.json
@@ -1,0 +1,57 @@
+{
+    "version": 1,
+    "disable_existing_loggers": false,
+    "formatters": {
+        "default": {
+            "()": "uvicorn.logging.DefaultFormatter",
+            "fmt": "%(levelprefix)s %(message)s",
+            "use_colors": null
+        },
+        "access": {
+            "()": "uvicorn.logging.AccessFormatter",
+            "fmt": "%(levelprefix)s %(client_addr)s - \"%(request_line)s\" %(status_code)s"
+        }
+    },
+    "handlers": {
+        "default": {
+            "formatter": "default",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stderr"
+        },
+        "access": {
+            "formatter": "access",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout"
+        },
+        "default-file": {
+            "formatter": "default",
+            "class": "logging.FileHandler",
+            "filename": "logs/default.log"
+        },
+        "access-file": {
+            "formatter": "access",
+            "class": "logging.FileHandler",
+            "filename": "logs/access.log"
+        }
+    },
+    "loggers": {
+        "uvicorn": {
+            "handlers": [
+                "default",
+                "default-file"
+            ],
+            "level": "INFO"
+        },
+        "uvicorn.error": {
+            "level": "INFO"
+        },
+        "uvicorn.access": {
+            "handlers": [
+                "access",
+                "access-file"
+            ],
+            "level": "INFO",
+            "propagate": false
+        }
+    }
+}

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+rm ./logs/*.log
+uvicorn app.main:app --reload-dir app --log-config=log_conf.json --host $(hostname --all-ip-address) --port ${1:-8000}


### PR DESCRIPTION
Log files are available at logs directory.
They are cleared each time the app runs.

Original uvicorn command has been wrapped by new 'run.sh' which is
likely to work most of the time(Unsure behavior of $(hostname
--all-ip-address).
'run.sh' expects one optinal argument: port. Default port is 8000.