### PR TITLE
Frontend skin page template

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,7 +13,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 ### in Docker Enviroment
 
 1. install docker
-2. `./dev-image.sh`
+2. (optional) `./dev-image.sh` - run after you modifying any package files.
 
 ## Development
 

--- a/frontend/dev-image.sh
+++ b/frontend/dev-image.sh
@@ -9,7 +9,7 @@
 #############################################################
 
 # argument
-if [ $1 == "update" ];
+if [ ${1:-no-update} == "update" ];
 then
     echo "Replace package.json and yarn.lock"
     cp ./testPackage/package.json ./package.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^12.1.10",
     "atomize": "^1.0.28",
     "axios": "^0.21.1",
+    "chart.js": "^3.5.1",
     "flickity": "^2.2.2",
     "http-proxy-middleware": "^2.0.1",
     "react": "^17.0.2",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,103 +1,52 @@
 import React from 'react';
 import './css/App.css';
-import { Div, Text } from "atomize";
+import { Div } from "atomize";
 
-import Nav from './components/NavAnchor';
-import RecommendCarousel from './components/RecommendCarousel';
-import ChampBox from './components/ChampBox';
+// route
+import {
+    BrowserRouter as Router,
+    Route,
+    Redirect,
+    Switch
+} from "react-router-dom";
+
+import Nav from "./components/NavAnchor";
+import Home from "./pages/Home";
+import Skins from "./pages/Skins";
 
 function App() {
 
     const anchorList = [
         { id: 0, name: "추천 스킨", link: "#recommend-skins", type: "hash" },
         { id: 1, name: "챔피언 목록", link: "#champions", type: "hash" },
-        { id: 2, name: "새 페이지", link: "/skins" }
+        { id: 2, name: "새 페이지", link: "/skins", type: "new-tab" },
+        { id: 3, name: "스킨", link: "/skins", type: "link" }
     ];
 
-    return (
-        <>
-            <Div className="main-background" />
-            <header className="main-header">
-                <Nav anchorList={anchorList} />
-            </header>
-            {/* body */}
-            <Div /* title */
-                d="flex"
-                h={{ xs: "150px", md: "400px" }}
-                align="center"
-                justify="center"
-                flexDir="column"
-            >
-                <Text
-                    p={{ l: "0.5rem", r: "0.5rem" }}
-                    textSize="display3"
-                    textAlign="center"
-                >
-                    LOL PRICE TRACKER
-                </Text>
-            </Div>
+    return (<>
+        <Div className="main-background" />
+        <header className="main-header">
+            <Nav anchorList={anchorList} />
+        </header>
 
-            <Div className="content-container" bg="black400" /* main content */ >
-                <Div className="content-background" bg="black600" /* background */ />
-
-                <div className="hash-link" id="recommend-skins" />
-                <Div
-                    w="100%"
-                    maxW="1024px"
-                    p={{
-                        t: "32px",
-                        l: "1rem",
-                        b: "1rem"
-                    }}
-                >
-                    <Text
-                        textSize={{ xs: "1rem", md: "1.5rem" }}
-                    >
-                        Recommend Skins
-                    </Text>
-                </Div>
-                <RecommendCarousel />
-
-                <div className="hash-link" id="champions" />
-                <Div
-                    w="100%"
-                    maxW="1024px"
-                    p={{ t: "32px", l: "1rem", b: "1rem" }}
-                >
-                    <Text
-                        textSize={{ xs: "1rem", md: "1.5rem" }}
-                    >
-                        Champion List
-                    </Text>
-                </Div>
-                <ChampBox />
-                <Div
-                    h="1000px"
-                    bg="brown"
-                    textSize="display3"
-                    textAlign="center"
-                >
-                    Dummy
-                </Div>
-                {/*
-                <div className="App-header">
-                    <img src="/images/logo.svg" className="App-logo" alt="logo" />
-                    <p>
-                        Edit <code>src/App.js</code> and save to reload.
-                    </p>
-                    <a
-                        className="App-link"
-                        href="https://reactjs.org"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        Learn React
-                    </a>
-                </div>
-                */}
-            </Div>
-        </>
-    );
+        <Switch>
+            <Route exact path="/">
+                <Redirect to="/home" />
+            </Route>
+            <Route exact path="/home">
+                <Home />
+            </Route>
+            <Route path="/skins/:skinId">
+                <Skins />
+            </Route>
+            <Route exect path="/skins">
+                <p>skin page</p>
+            </Route>
+            <Route path="/">
+                <p>404 error</p>
+            </Route>
+        </Switch>
+    </>);
 }
 
 export default App;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,10 +17,11 @@ import Skins from "./pages/Skins";
 function App() {
 
     const anchorList = [
-        { id: 0, name: "추천 스킨", link: "#recommend-skins", type: "hash" },
-        { id: 1, name: "챔피언 목록", link: "#champions", type: "hash" },
-        { id: 2, name: "새 페이지", link: "/skins", type: "new-tab" },
-        { id: 3, name: "스킨", link: "/skins", type: "link" }
+        { id: 0, name: "홈", link: "/home", type: "link" },
+        { id: 1, name: "추천 스킨", link: "#recommend-skins", type: "hash" },
+        { id: 2, name: "챔피언 목록", link: "#champions", type: "hash" },
+        { id: 3, name: "새 페이지", link: "/skins", type: "new-tab" },
+        { id: 4, name: "스킨", link: "/skins", type: "link" }
     ];
 
     return (<>

--- a/frontend/src/components/NavAnchor.js
+++ b/frontend/src/components/NavAnchor.js
@@ -2,7 +2,7 @@ import React from 'react';
 import "../css/NavAnchor.css";
 import { Link } from "react-router-dom";
 import { HashLink } from "react-router-hash-link";
-import { Button } from "atomize";
+import { Button, Anchor } from "atomize";
 
 function Nav({ anchorList }) {
 
@@ -25,21 +25,39 @@ function Nav({ anchorList }) {
                             </Button>
                         </HashLink>
                     );
-                else return (
-                    <Link
-                        key={item.id}
-                        to={item.link}
-                    >
-                        <Button
-                            bg="info700"
-                            hoverBg="info600"
-                            cursor="pointer"
-                            rounded="md"
+                else if (item.type === "new-tab")
+                    return (
+                        <Anchor
+                            key={item.id}
+                            href={item.link}
+                            target="_blank"
                         >
-                            {item.name}
-                        </Button>
-                    </Link>
-                );
+                            <Button
+                                bg="info700"
+                                hoverBg="info600"
+                                cursor="pointer"
+                                rounded="md"
+                            >
+                                {item.name}
+                            </Button>
+                        </Anchor>
+                    );
+                else 
+                    return (
+                        <Link
+                            key={item.id}
+                            to={item.link}
+                        >
+                            <Button
+                                bg="info700"
+                                hoverBg="info600"
+                                cursor="pointer"
+                                rounded="md"
+                            >
+                                {item.name}
+                            </Button>
+                        </Link>
+                    );
             }
             )}
         </nav>

--- a/frontend/src/components/RecommendCarousel.js
+++ b/frontend/src/components/RecommendCarousel.js
@@ -19,7 +19,7 @@ function RecommendCarousel() {
     return (<>{
         isLoading ? <p> is loading... </p> :
         isError ? <p> something error </p> :
-        <Div w="100%">
+        <Div maxW="100%">
             <Carousel list={skinList} flktyOption={flickityOptions} cellOption={{ type: "recommend-skins" }} />
         </Div>
     }</>);

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -73,13 +73,18 @@
 }
 
 .content-container > * {
+  width: 100%;
+  max-width: 1024px;
   z-index: 1;
 }
 
 .content-container > .content-title {
-  width: 100%;
-  max-width: 1024px;
   padding: 32px 0 1rem 1rem; 
+}
+
+.chart-container {
+  position: relative;
+  height:400px;
 }
 
 .hash-link {

--- a/frontend/src/css/App.css
+++ b/frontend/src/css/App.css
@@ -43,8 +43,7 @@
 .main-header {
   position: sticky;
   background-color: black;
-  padding-top: 16px;
-  top: -16px;
+  top: 0;
   z-index: 3;
 }
 
@@ -75,6 +74,12 @@
 
 .content-container > * {
   z-index: 1;
+}
+
+.content-container > .content-title {
+  width: 100%;
+  max-width: 1024px;
+  padding: 32px 0 1rem 1rem; 
 }
 
 .hash-link {

--- a/frontend/src/hooks/useDataFetch.js
+++ b/frontend/src/hooks/useDataFetch.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useReducer } from "react";
+import { useState, useEffect, useReducer } from "react";
 import axios from "axios";
 
 function dataFetchReducer(state, action) {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,21 +1,14 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './css/index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./css/index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
 
 // Theme
 import { Provider as StyletronProvider, DebugEngine } from "styletron-react";
 import { Client as Styletron } from "styletron-engine-atomic";
-import { ThemeProvider, StyleReset } from 'atomize';
-
-// route
-import {
-    BrowserRouter as Router,
-    Route,
-    Redirect,
-    Switch
-} from "react-router-dom";
+import { ThemeProvider, StyleReset } from "atomize";
+import { BrowserRouter as Router } from "react-router-dom";
 
 const theme = {
     colors: {
@@ -38,20 +31,7 @@ ReactDOM.render(
             <ThemeProvider theme={theme}>
                 <StyleReset />
                 <Router>
-                    <Switch>
-                        <Route exact path="/">
-                            <Redirect to="/home" />
-                        </Route>
-                        <Route exact path="/home">
-                            <App />
-                        </Route>
-                        <Route path="/skins">
-                            <p>skin page</p>
-                        </Route>
-                        <Route path="/">
-                            <p>404 error</p>
-                        </Route>
-                    </Switch>
+                    <App />
                 </Router>
             </ThemeProvider>
         </StyletronProvider>

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -1,0 +1,86 @@
+import React from "react";
+import { Div, Text } from "atomize";
+import RecommendCarousel from '../components/RecommendCarousel';
+import ChampBox from '../components/ChampBox';
+
+function Home() {
+    return (<>
+        <Div /* title */
+            d="flex"
+            h={{ xs: "150px", md: "400px" }}
+            align="center"
+            justify="center"
+            flexDir="column"
+        >
+            <Text
+                p={{ l: "0.5rem", r: "0.5rem" }}
+                textSize="display3"
+                textAlign="center"
+            >
+                LOL PRICE TRACKER
+            </Text>
+        </Div>
+
+        <Div className="content-container" bg="black400" /* main content */ >
+            <Div className="content-background" bg="black600" /* background */ />
+
+            <div className="hash-link" id="recommend-skins" />
+            <Div
+                w="100%"
+                maxW="1024px"
+                p={{
+                    t: "32px",
+                    l: "1rem",
+                    b: "1rem"
+                }}
+            >
+                <Text
+                    textSize={{ xs: "1rem", md: "1.5rem" }}
+                >
+                    Recommend Skins
+                </Text>
+            </Div>
+            <RecommendCarousel />
+
+            <div className="hash-link" id="champions" />
+            <Div
+                w="100%"
+                maxW="1024px"
+                p={{ t: "32px", l: "1rem", b: "1rem" }}
+            >
+                <Text
+                    textSize={{ xs: "1rem", md: "1.5rem" }}
+                >
+                    Champion List
+                </Text>
+            </Div>
+            <ChampBox />
+            <Div
+                h="1000px"
+                bg="brown"
+                textSize="display3"
+                textAlign="center"
+            >
+                Dummy
+            </Div>
+            {/*
+            <div className="App-header">
+                <img src="/images/logo.svg" className="App-logo" alt="logo" />
+                <p>
+                    Edit <code>src/App.js</code> and save to reload.
+                </p>
+                <a
+                    className="App-link"
+                    href="https://reactjs.org"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Learn React
+                </a>
+            </div>
+            */}
+        </Div>
+    </>);
+}
+
+export default Home;

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -25,35 +25,23 @@ function Home() {
             <Div className="content-background" bg="black600" /* background */ />
 
             <div className="hash-link" id="recommend-skins" />
-            <Div
-                w="100%"
-                maxW="1024px"
-                p={{
-                    t: "32px",
-                    l: "1rem",
-                    b: "1rem"
-                }}
-            >
+            <div className="content-title">
                 <Text
                     textSize={{ xs: "1rem", md: "1.5rem" }}
                 >
                     Recommend Skins
                 </Text>
-            </Div>
+            </div>
             <RecommendCarousel />
 
             <div className="hash-link" id="champions" />
-            <Div
-                w="100%"
-                maxW="1024px"
-                p={{ t: "32px", l: "1rem", b: "1rem" }}
-            >
+            <div className="content-title">
                 <Text
                     textSize={{ xs: "1rem", md: "1.5rem" }}
                 >
                     Champion List
                 </Text>
-            </Div>
+            </div>
             <ChampBox />
             <Div
                 h="1000px"

--- a/frontend/src/pages/Skins.js
+++ b/frontend/src/pages/Skins.js
@@ -1,0 +1,50 @@
+import React, { useEffect } from "react";
+import { Div, Text } from "atomize";
+import useDataFetch from "../hooks/useDataFetch";
+
+/**
+ * 
+ * page for skin information
+ * url : /skins/:skinId
+ * 
+ */
+
+function Skins({ match, location }) {
+    const [{ isLoading, isError, data: skin }, _] = useDataFetch(
+        "initialUrl",
+        {}
+    );
+    const [ChampionSkinList, doFetch] = useDataFetch(
+        "initialUrl",
+        []
+    );
+    useEffect(() => {
+        doFetch(`/fastapi/api/champions/${skin.champion_id}/skins`);
+    }, [skin]);
+
+    return (<>
+        <Div /* title */
+            d="flex"
+            h={{ xs: "150px", md: "400px" }}
+            align="center"
+            justify="center"
+            flexDir="column"
+        >
+            <Text
+                p={{ l: "0.5rem", r: "0.5rem" }}
+                textSize="display3"
+                textAlign="center"
+            >
+                {skin.name}
+            </Text>
+        </Div>
+        <Div className="content-container" bg="black400" /* main content */ >
+            <Div className="content-background" bg="black600" /* background */ />
+            <Div>
+
+            </Div>
+        </Div>
+    </>);
+}
+
+export default Skins;

--- a/frontend/src/pages/Skins.js
+++ b/frontend/src/pages/Skins.js
@@ -1,6 +1,10 @@
 import React, { useEffect } from "react";
-import { Div, Text } from "atomize";
+import { Div, Image, Text } from "atomize";
+import { useRouteMatch } from "react-router-dom";
+
 import useDataFetch from "../hooks/useDataFetch";
+import Carousel from "../components/Carousel";
+
 
 /**
  * 
@@ -9,39 +13,73 @@ import useDataFetch from "../hooks/useDataFetch";
  * 
  */
 
-function Skins({ match, location }) {
-    const [{ isLoading, isError, data: skin }, _] = useDataFetch(
-        "initialUrl",
+function Skins() {
+    const { params } = useRouteMatch("/skins/:skinId");
+    useEffect(() => {
+        doSkinFetch(`/fastapi/api/skins/${params.skinId}`);
+    }, [params]);
+
+    const [{ isLoading, isError, data: skin }, doSkinFetch] = useDataFetch(
+        `/fastapi/api/skins/${params.skinId}`,
         {}
     );
-    const [ChampionSkinList, doFetch] = useDataFetch(
+
+    const [{data: championSkinList}, doChampionFetch] = useDataFetch(
         "initialUrl",
         []
     );
+    const flickityOptions = {
+        initialIndex: 1,
+        wrapAround: true,
+        autoPlay: 3000,
+    };
     useEffect(() => {
-        doFetch(`/fastapi/api/champions/${skin.champion_id}/skins`);
+        if (skin.champion_id !== undefined) {
+            doChampionFetch(`/fastapi/api/champions/${skin.champion_id}/skins`);
+        }
     }, [skin]);
 
     return (<>
-        <Div /* title */
-            d="flex"
-            h={{ xs: "150px", md: "400px" }}
-            align="center"
-            justify="center"
-            flexDir="column"
+        <Div
+            pos="fixed"
+            w="100%"
+            h="100%"
         >
-            <Text
-                p={{ l: "0.5rem", r: "0.5rem" }}
+            <Image
+                src={skin.full_image_url}
+                w="100%"
+            />
+        </Div>
+        <Div p="200px"></Div>
+        <Div className="content-container" bg="transparent" /* main content */ >
+            <Div className="content-background" bg="black600" />
+            <div className="content-title">
+                <Text
+                    textSize={{ xs: "1rem", md: "1.5rem" }}
+                >
+                    {skin.name}
+                </Text>
+            </div>
+            <div className="content-title">
+                <Text
+                    textSize={{ xs: "1rem", md: "1.5rem" }}
+                >
+                    챔피언의 다른 스킨들
+                </Text>
+            </div>
+            <Div
+                p={{y:"1rem"}} 
+                w="100%"
+            >
+                <Carousel list={championSkinList} flktyOption={flickityOptions} cellOption={{ type: "champion-skins" }} />
+            </Div>
+            <Div
+                h="1000px"
+                bg="brown"
                 textSize="display3"
                 textAlign="center"
             >
-                {skin.name}
-            </Text>
-        </Div>
-        <Div className="content-container" bg="black400" /* main content */ >
-            <Div className="content-background" bg="black600" /* background */ />
-            <Div>
-
+                Dummy
             </Div>
         </Div>
     </>);

--- a/frontend/src/pages/Skins.js
+++ b/frontend/src/pages/Skins.js
@@ -1,6 +1,7 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { Div, Image, Text } from "atomize";
 import { useRouteMatch } from "react-router-dom";
+import { Chart, registerables } from 'chart.js';
 
 import useDataFetch from "../hooks/useDataFetch";
 import Carousel from "../components/Carousel";
@@ -15,15 +16,67 @@ import Carousel from "../components/Carousel";
 
 function Skins() {
     const { params } = useRouteMatch("/skins/:skinId");
+    // update when skin id changed
     useEffect(() => {
         doSkinFetch(`/fastapi/api/skins/${params.skinId}`);
     }, [params]);
 
+    // skin data fetch
     const [{ isLoading, isError, data: skin }, doSkinFetch] = useDataFetch(
         `/fastapi/api/skins/${params.skinId}`,
         {}
     );
 
+    //chart data
+    const chartRef = useRef(null);
+    useEffect(() => {
+        const ctx = chartRef.current.getContext("2d");
+        Chart.register(...registerables);
+        
+        const history = skin.price_history || [];
+        console.log(history);
+
+        history.sort();
+        const labels = history.map(item => item.date);
+        const datas = history.map(item => item.price);
+        // dummy
+        //const labels = ["a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d", "a", "b", "c", "d"];
+        //const datas = [65, 59, 80, 81, 56, 55, 40, 65, 59, 80, 81, 56, 55, 40, 65, 59, 80, 81, 56, 55];
+
+        const data = {
+          labels: labels,
+          datasets: [{
+            label: 'My First Dataset',
+            data: datas,
+            fill: false,
+            borderColor: 'rgb(75, 192, 192)',
+            tension: 0
+          }]
+        };
+        
+        const chart = new Chart(ctx, {
+            type: 'line',
+            data: data,
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        stackWeight: 1
+                    }
+                }
+            }
+        });
+        console.log(chart);
+
+        return () => {
+            console.log("chart destroy...");
+            chart.destroy();
+        };
+    }, [skin]);
+
+    // skin list fetch
     const [{data: championSkinList}, doChampionFetch] = useDataFetch(
         "initialUrl",
         []
@@ -44,6 +97,7 @@ function Skins() {
             pos="fixed"
             w="100%"
             h="100%"
+            minW="700px"
         >
             <Image
                 src={skin.full_image_url}
@@ -60,6 +114,9 @@ function Skins() {
                     {skin.name}
                 </Text>
             </div>
+            <div className="chart-container">
+                <canvas ref={chartRef}></canvas>
+            </div>
             <div className="content-title">
                 <Text
                     textSize={{ xs: "1rem", md: "1.5rem" }}
@@ -68,8 +125,8 @@ function Skins() {
                 </Text>
             </div>
             <Div
-                p={{y:"1rem"}} 
-                w="100%"
+                p={{y:"1rem"}}
+                maxW="100%"
             >
                 <Carousel list={championSkinList} flktyOption={flickityOptions} cellOption={{ type: "champion-skins" }} />
             </Div>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3162,6 +3162,11 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
+chart.js@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.5.1.tgz#73e24d23a4134a70ccdb5e79a917f156b6f3644a"
+  integrity sha512-m5kzt72I1WQ9LILwQC4syla/LD/N413RYv2Dx2nnTkRS9iv/ey1xLTt0DnPc/eWV4zI+BgEgDYBIzbQhZHc/PQ==
+
 check-types@^11.1.1:
   version "11.1.2"
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-11.1.2.tgz#86a7c12bf5539f6324eb0e70ca8896c0e38f3e2f"


### PR DESCRIPTION
## pull request about #16 

### implement skin page!
- url : /skins/{skin_id}
- this page shows skin information corresponding to the skin id.
- have three component
  - timeline graph about skin price
  - skin info (name, ... would be updated)
  - carousel for other skins for champion of the skin
 ### router structure changed
- route code moved from 'index.js' to 'App.js'
- url
  - '/home' : main page (implemented in 'src/pages/Home.js')
  - '/' : redirected to '/home'
  - '/skins/{skin_id}' : skin page (implemented in 'src/page/Skins.js')
  - others : route to 404 page