### PR TITLE
Backend update script fix

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -78,7 +78,7 @@ $ poetry shell
 # Update static data
 ```bash
 $ cd /path/to/update_scripts
-$ poetry run python update_static.py
+$ poetry run update_static.py
 ```
 <br/>
 <br/>

--- a/backend/generate_test_database.sh
+++ b/backend/generate_test_database.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Generate an empty database on 12.7 PostgreSQL container, configured by $src_profile.
 # And populate the database with some random test data
 # If -c|--clone argument is passed, clone the database pointed by $dst_profile to the generated database.
@@ -84,6 +84,6 @@ elif [ "$MODE" = "GEN_TEST_DATA" ]; then
     echo "Populating the generated database with test data..."
     
     alembic upgrade head
-    echo "\n" | python update_scripts/update_static.py
-    echo "\n" | python update_scripts/gen_test_history.py
+    echo "\n" | update_scripts/update_static.py
+    echo "\n" | update_scripts/gen_test_history.py
 fi

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PORT=8000
 

--- a/backend/see_db.py
+++ b/backend/see_db.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # import sqlite3
 
 # con = sqlite3.connect("sqlite3.db")

--- a/backend/update_scripts/gen_test_history.py
+++ b/backend/update_scripts/gen_test_history.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from datetime import date, timedelta
 import random
 

--- a/backend/update_scripts/update_price_history.py
+++ b/backend/update_scripts/update_price_history.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import time
 import asyncio
 from datetime import date

--- a/backend/update_scripts/update_static.py
+++ b/backend/update_scripts/update_static.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import requests
 from tqdm import tqdm
 

--- a/backend/update_scripts/update_static.py
+++ b/backend/update_scripts/update_static.py
@@ -7,16 +7,32 @@ from app import models
 
 def update(db, version, champion):
     icon_url = f'http://ddragon.leagueoflegends.com/cdn/{version}/img/champion/{champion["id"]}.png'
-    db_champion = models.Champion(id=int(champion['key']), name=champion['name'], icon_url=icon_url)
-    db.add(db_champion)
-    champion_url = f'http://ddragon.leagueoflegends.com/cdn/{version}/data/ko_KR/champion/{champion["id"]}.json'
 
+    db_champion = db.query(models.Champion).filter(models.Champion.id == int(champion['key'])).first()
+    if db_champion is None:
+        db_champion = models.Champion(id=int(champion['key']), name=champion['name'], icon_url=icon_url)
+        db.add(db_champion)
+    else:
+        db_champion.id = int(champion['key'])
+        db_champion.name = champion['name']
+        db_champion.icon_url = icon_url
+
+    champion_url = f'http://ddragon.leagueoflegends.com/cdn/{version}/data/ko_KR/champion/{champion["id"]}.json'
     skins = requests.get(champion_url).json()['data'][champion['id']]['skins']
     for skin in skins:
         trimmed_image_url = f'http://ddragon.leagueoflegends.com/cdn/img/champion/loading/{champion["id"]}_{skin["num"]}.jpg'
         full_image_url = f'http://ddragon.leagueoflegends.com/cdn/img/champion/splash/{champion["id"]}_{skin["num"]}.jpg'
-        db_skin = models.Skin(id=skin['id'], name=skin['name'], trimmed_image_url=trimmed_image_url, full_image_url=full_image_url, champion=db_champion)
-        db.add(db_skin)
+
+        db_skin = db.query(models.Skin).filter(models.Skin.id == skin['id']).first()
+        if db_skin is None:
+            db_skin = models.Skin(id=skin['id'], name=skin['name'], trimmed_image_url=trimmed_image_url, full_image_url=full_image_url, champion=db_champion)
+            db.add(db_skin)
+        else:
+            db_skin.id = skin['id']
+            db_skin.name = skin['name']
+            db_skin.trimmed_image_url = trimmed_image_url
+            db_skin.full_image_url = full_image_url
+            db_skin.champion = db_champion
     
 
 def main():
@@ -27,16 +43,10 @@ def main():
     champions = requests.get(champions_url).json()['data']
 
     print(f'Fetched {len(champions)} champions from version {version}.')
-    print('!!!CAUTION!!!')
-    print(f'Do you want to reconstruct {models.Champion.__tablename__!r} and {models.Skin.__tablename__!r} table?')
+    print(f'Do you want to update {models.Champion.__tablename__!r} and {models.Skin.__tablename__!r} table?')
     input('Press Enter to continue...')
 
     with SessionLocal() as db:
-        # ----- Replace these lines with SQL Update logic -----
-        db.query(models.Champion).delete()
-        db.query(models.Skin).delete()
-        # ----- Replace these lines with SQL Update logic -----
-
         for champion in tqdm(champions.values()):
             update(db, version, champion)
         db.commit()


### PR DESCRIPTION
update_static.py now use UPDATE instead of DELETE then INSERT again.
So it can safely run on production server.(To update new champions and skins)

Previous update_static.py was horrible and only work on test database.

Some frequently used update scripts also included python shebang to be able to run directly from bash.