### PR TITLE
Backend migrate api server

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+# https://fastapi.tiangolo.com/deployment/docker/#deploy-the-container-image
+
+FROM python:3.9 as requirements-stage
+WORKDIR /tmp
+RUN pip install poetry
+COPY ./pyproject.toml ./poetry.lock* /tmp/
+RUN poetry export -f requirements.txt --output requirements.txt --without-hashes
+
+FROM python:3.9
+WORKDIR /code
+COPY --from=requirements-stage /tmp/requirements.txt /code/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+COPY ./app /code/app
+CMD ["uvicorn", "app.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "80"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,19 +13,6 @@ $ cd /path/to/backend/
 $ poetry install
 ```
 
-## Generate test database for development
-```bash
-$ cd /path/to/backend/
-$ ./generate_test_database.sh [-m mode]
-```
-Generate the test database based on `dst_profile`(by default, `[test]` in `db_config.ini`) on local postgre container.
-
-Then populate the database with `update_scripts/update_static.py` and `update_scripts/gen_test_history.py`.
-
-If `mode=clone`, then instead of populating the database with random test data, the `src_profile`(by default, `[production]` in `db_config.ini`) is cloned to the generated database.
-
-If `mode=empty`, then the generated database is kept clean.
-
 <br/>
 <br/>
 
@@ -47,6 +34,25 @@ Visit
 localhost:8000/docs
 ```
 for available APIs and their documentation.
+
+
+## With Docker
+Implementing...
+
+
+
+## Generate test database for development
+```bash
+$ cd /path/to/backend/
+$ ./generate_test_database.sh [-m mode]
+```
+Generate the test database based on `dst_profile`(by default, `[test]` in `db_config.ini`) on local postgre container.
+
+Then populate the database with `update_scripts/update_static.py` and `update_scripts/gen_test_history.py`.
+
+If `mode=clone`, then instead of populating the database with random test data, the `src_profile`(by default, `[production]` in `db_config.ini`) is cloned to the generated database.
+
+If `mode=empty`, then the generated database is kept clean.
 
 <br/>
 <br/>

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -17,19 +17,26 @@ try:
     engine = create_engine(DB_URL)
     print(f'[Current DB]: {db_config["prompt_name"]}')
 except Exception:
-    DB_URL = f'sqlite:///{os.path.join(os.path.dirname(__file__), "../sqlite3.db")}'
-    engine = create_engine(DB_URL, connect_args={"check_same_thread": False})
-    print(f'[Current DB]: local SQLite')
+    try:
+        print('"db_config.ini" is not found or invalid.')
+        print('Reading from environment variable...')
+        db_config = os.environ
+        DB_URL = f'postgresql+psycopg2://{db_config["POSTGRESQL_USERNAME"]}:{db_config["POSTGRESQL_PASSWORD"]}@{db_config["POSTGRESQL_HOST"]}:{db_config["POSTGRESQL_PORT"]}/{db_config["POSTGRESQL_DB"]}'
+        engine = create_engine(DB_URL)
+    except:
+        DB_URL = f'sqlite:///{os.path.join(os.path.dirname(__file__), "../sqlite3.db")}'
+        engine = create_engine(DB_URL, connect_args={"check_same_thread": False})
+        print(f'[Current DB]: local SQLite')
 
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 convention = {
-  "ix": 'ix_%(column_0_label)s',
-  "uq": "uq_%(table_name)s_%(column_0_name)s",
-  "ck": "ck_%(table_name)s_%(constraint_name)s",
-  "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
-  "pk": "pk_%(table_name)s"
+    "ix": 'ix_%(column_0_label)s',
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s"
 }
 
 Base = declarative_base(metadata=MetaData(naming_convention=convention))

--- a/backend/generate_test_database.sh
+++ b/backend/generate_test_database.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Generate an empty database on 12.7 PostgreSQL container, configured by $src_profile.
 # And populate the database with some random test data
-# If -c|--clone argument is passed, clone the database pointed by $dst_profile to the generated database.
-# If -e|--empty arugment is passed, the generated database is kept empty.
+# -m|--mode CLONE to clone the production server
+# -m|--mode GEN_TEST_DATA to populate with test data
+# no -m|--mode to create empty database
 
 src_profile=production
 dst_profile=test


### PR DESCRIPTION
Added containerization for `app`
API server migrated from EC2 to ECS which use the image defined in the added dockerfile.

Docker Compose file for local development and Task definition file for deployment will be added later.